### PR TITLE
feat: viewer count per channel

### DIFF
--- a/packages/demo/src/util.ts
+++ b/packages/demo/src/util.ts
@@ -8,6 +8,15 @@ export async function watch(channelUrl, video) {
   }
 }
 
+export async function getViewerCount(channelUrl): Promise<number> {
+  const response = await fetch(channelUrl);
+  if (response.ok) {
+    const json = await response.json();
+    return json.viewers;
+  }
+  return -1;
+}
+
 export function getIceServers(): WHIPClientIceServer[] {
   let iceServers: WHIPClientIceServer[] = [{ urls: "stun:stun.l.google.com:19302" }];
 

--- a/packages/demo/src/watch.html
+++ b/packages/demo/src/watch.html
@@ -9,5 +9,6 @@
   </head>
   <body>
     <video autoplay muted controls></video>
+    <div id="viewercount"></div>
   </body>
 </html>

--- a/packages/demo/src/watch.ts
+++ b/packages/demo/src/watch.ts
@@ -1,10 +1,15 @@
-import { watch } from "./util";
+import { getViewerCount, watch } from "./util";
 
 window.addEventListener("DOMContentLoaded", async () => {
   const searchParams = new URL(window.location.href).searchParams;
   const locator = searchParams.get("locator");
 
   if (locator) {
-    await watch(locator, document.querySelector<HTMLVideoElement>("video"))
+    await watch(locator, document.querySelector<HTMLVideoElement>("video"));
+
+    const t = setInterval(async () => { 
+      const viewerCount = await getViewerCount(locator);
+      document.querySelector<HTMLDivElement>("#viewercount").innerHTML = `${viewerCount} viewers`;  
+    }, 5000);
   }
 }); 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -52,7 +52,7 @@ Included is also a dummy endpoint if you just want to test the connectivity. Use
 ### Environment variables
 
 The following environment variables are read to override default values:
-- `ICE_TRICKLE_TIMEOUT` (default: 4000 ms): Timeout for gathering all ICE candidates
+- `ICE_GATHERING_TIMEOUT` (default: 4000 ms): Timeout for gathering all ICE candidates
 - `API_KEY`: Authorization key that clients must use to get ICE server config on OPTIONS request
 
 ## Broadcaster

--- a/packages/server/src/broadcaster/api.ts
+++ b/packages/server/src/broadcaster/api.ts
@@ -1,72 +1,21 @@
 import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
-import { RTCPeerConnection } from "wrtc";
-
-const ICE_TRICKLE_TIMEOUT = process.env.ICE_TRICKLE_TIMEOUT ? parseInt(process.env.ICE_TRICKLE_TIMEOUT) : 4000;
-
-const waitUntilIceGatheringStateComplete = async (peer: RTCPeerConnection, channelId) => {
-  if (peer.iceGatheringState === "complete") {
-    return;
-  }
-
-  const p: Promise<void> = new Promise((resolve, reject) => {
-    const t = setTimeout(() => {
-      peer.removeEventListener("icecandidate", onIceCandidate);
-      console.log("SFU PEER: ICE gathering timed out, send what we have");
-      resolve();
-    }, ICE_TRICKLE_TIMEOUT);
-    const onIceCandidate = ({ candidate }) => {
-      if (!candidate) {
-        clearTimeout(t);
-        peer.removeEventListener("icecandidate", onIceCandidate);
-        console.log(`SFU ${channelId}: ICE candidates gathered: state=${peer.iceConnectionState}`);
-        resolve();
-      } else {
-        console.log(`SFU ${channelId}: ${candidate.candidate}`);
-      }
-    };
-    peer.addEventListener("icecandidate", onIceCandidate);
-  });
-  await p;
-}
+import { Viewer } from "./viewer";
 
 export default function(fastify: FastifyInstance, opts, done) {
 
   fastify.post("/channel/:channelId", {}, async (request: any, reply: FastifyReply) => {
     try {
       const channelId = request.params.channelId;
-      const iceServers = opts.instance.getIceServers();
-      const peer = new RTCPeerConnection({
-        sdpSemantics: "unified-plan",
-        iceServers: iceServers,
-      });
-      peer.oniceconnectionstatechange = () => console.log(`SFU ${channelId}: connection=${peer.iceConnectionState}`);
-      peer.onicegatheringstatechange = e => console.log(`SFU ${channelId}: gathering=${peer.iceGatheringState}`);
-      peer.onicecandidateerror = e => console.error(`SFU ${channelId}: ${e.url} returned an error with code ${e.errorCode}: ${e.errorText}`);
-      peer.onconnectionstatechange = async (e) => {
-        console.log(`SFU ${channelId}: peerconnection=${peer.connectionState}`);
-        if (["disconnected", "closed", "failed"].includes(peer.connectionState)) {
-          console.log(`SFU ${channelId}: watcher closed connection, remove track from senders`);
-          peer.getSenders().map(sender => peer.removeTrack(sender));
-        }
-      };
-  
+      const iceServers = opts.broadcaster.getIceServers();
+
+      const viewer = new Viewer(channelId, { iceServers: iceServers });
+      viewer.on("connect", () => { opts.broadcaster.incrementViewer(channelId); });
+      viewer.on("disconnect", () => { opts.broadcaster.decreaseViewer(channelId); });
+      
       const remoteSdp = request.body.sdp;
-      await peer.setRemoteDescription({ 
-        type: "offer", 
-        sdp: remoteSdp 
-      });
-
-      const stream = opts.instance.getStreamForChannel(channelId);
-      for (const track of stream.getTracks()) {
-        console.log(`SFU ${channelId}: Added track: ` + track.kind);
-        peer.addTrack(track, stream);
-      }
-
-      const answer = await peer.createAnswer();
-      await peer.setLocalDescription(answer);
-      await waitUntilIceGatheringStateComplete(peer, channelId);
-
-      reply.code(200).send({ type: "answer", sdp: peer.localDescription.sdp });
+      const stream = opts.broadcaster.getStreamForChannel(channelId);
+      const answer = await viewer.handleOffer(remoteSdp, stream);
+      reply.code(200).send({ type: "answer", sdp: answer });
     } catch (err) {
       console.error(err);
       reply.code(500).send(err.message);
@@ -75,10 +24,23 @@ export default function(fastify: FastifyInstance, opts, done) {
 
   fastify.get("/channel", {}, async (request: any, reply: FastifyReply) => {
     try {
-      const channels = opts.instance.getChannels();
+      const channels = opts.broadcaster.getChannels();
       reply.code(200).send(channels.map(channelId => {
-        return { channelId: channelId, resource: opts.instance.getBaseUrl() + "/channel/" + channelId };
+        return { channelId: channelId, resource: opts.broadcaster.getBaseUrl() + "/channel/" + channelId };
       }));
+    } catch (err) {
+      console.error(err);
+      reply.code(500).send(err.message);
+    }
+  });
+
+  fastify.get("/channel/:channelId", {}, async (request: any, reply: FastifyReply) => {
+    try {
+      const channelId = request.params.channelId;
+      reply.code(200).send({
+        channelId: channelId,
+        viewers: opts.broadcaster.getViewers(channelId),
+      });
     } catch (err) {
       console.error(err);
       reply.code(500).send(err.message);

--- a/packages/server/src/broadcaster/index.ts
+++ b/packages/server/src/broadcaster/index.ts
@@ -3,7 +3,7 @@ import { MediaStream } from "wrtc";
 
 import api from "./api";
 
-interface BroadcasterICEServer {
+export interface BroadcasterICEServer {
   urls: string;
   username?: string;
   credential?: string;
@@ -19,6 +19,7 @@ interface BroadcasterOptions {
 export class Broadcaster {
   private server: FastifyInstance;
   private channels: Map<string, MediaStream>;
+  private viewers: Map<string, number>;
   private port: number;
   private baseUrl: string;
   private prefix: string;
@@ -46,9 +47,10 @@ export class Broadcaster {
 
     this.server = fastify({ ignoreTrailingSlash: true });
     this.server.register(require("fastify-cors"));
-    this.server.register(api, { prefix: this.prefix, instance: this });
+    this.server.register(api, { prefix: this.prefix, broadcaster: this });
 
     this.channels = new Map();
+    this.viewers = new Map();
   }
 
   createChannel(channelId: string, stream: MediaStream) {
@@ -69,6 +71,24 @@ export class Broadcaster {
 
   removeChannel(channelId: string) {
     this.channels.delete(channelId);
+  }
+
+  incrementViewer(channelId) {
+    if (!this.viewers.get(channelId)) {
+      this.viewers.set(channelId, 0);
+    }
+    this.viewers.set(channelId, this.viewers.get(channelId) + 1);
+  }
+
+  decreaseViewer(channelId) {
+    if (!this.viewers.get(channelId)) {
+      this.viewers.set(channelId, 1);
+    }
+    this.viewers.set(channelId, this.viewers.get(channelId) - 1);
+  }
+
+  getViewers(channelId) {
+    return this.viewers.get(channelId) || 0;
   }
 
   getBaseUrl() {

--- a/packages/server/src/broadcaster/viewer.ts
+++ b/packages/server/src/broadcaster/viewer.ts
@@ -1,0 +1,106 @@
+import { RTCPeerConnection } from "wrtc";
+import { v4 as uuidv4 } from "uuid";
+
+import { BroadcasterICEServer } from ".";
+import { EventEmitter } from "events";
+
+const ICE_TRICKLE_TIMEOUT = process.env.ICE_TRICKLE_TIMEOUT ? parseInt(process.env.ICE_TRICKLE_TIMEOUT) : 4000;
+
+export interface ViewerOptions {
+  iceServers?: BroadcasterICEServer[];
+}
+
+export class Viewer extends EventEmitter {
+  private channelId: string;
+  private viewerId: string;
+  private peer: RTCPeerConnection;
+
+  constructor(channelId: string, opts) {
+    super();
+    this.channelId = channelId;
+    this.viewerId = uuidv4();
+
+    this.peer = new RTCPeerConnection({
+      sdpSemantics: "unified-plan",
+      iceServers: opts.iceServers,
+    });
+
+    this.peer.onicegatheringstatechange = this.onIceGatheringStateChange.bind(this);
+    this.peer.oniceconnectionstatechange = this.onIceConnectionStateChange.bind(this);
+    this.peer.onicecandidateerror = this.onIceCandidateError.bind(this);
+
+    this.peer.onconnectionstatechange = this.onConnectionStateChange.bind(this);
+  }
+
+  private onIceGatheringStateChange(e) {
+    this.log("IceGatheringState", this.peer.iceGatheringState);
+  }
+  
+  private onIceConnectionStateChange(e) {
+    this.log("IceConnectionState", this.peer.iceConnectionState);
+  }
+
+  private onIceCandidateError(e) {
+    this.log("IceCandidateError", e);
+  }
+
+  private onConnectionStateChange(e) {
+    this.log("ConnectionState", this.peer.connectionState);
+
+    if (["disconnected", "closed", "failed"].includes(this.peer.connectionState)) {
+      this.log(`watcher closed connection, remove track from senders`);
+      this.peer.getSenders().map(sender => this.peer.removeTrack(sender));
+      this.emit("disconnect");
+    }
+  }
+
+  private async waitUntilIceGatheringStateComplete(): Promise<void> {
+    if (this.peer.iceGatheringState === "complete") {
+      return;
+    }
+  
+    const p: Promise<void> = new Promise((resolve, reject) => {
+      const t = setTimeout(() => {
+        this.peer.removeEventListener("icecandidate", onIceCandidate);
+        console.log("SFU PEER: ICE gathering timed out, send what we have");
+        resolve();
+      }, ICE_TRICKLE_TIMEOUT);
+
+      const onIceCandidate = ({ candidate }) => {
+        if (!candidate) {
+          clearTimeout(t);
+          this.peer.removeEventListener("icecandidate", onIceCandidate);
+          this.log("ICE candidates gathered");
+          resolve();
+        } else {
+          this.log(candidate.candidate);
+        }
+      };
+      this.peer.addEventListener("icecandidate", onIceCandidate);
+    });
+    await p;
+  }
+
+  private log(...args: any[]) {
+    console.log(`SFU ${this.viewerId}`, ...args);
+  }
+
+  async handleOffer(offer: string, stream) {
+    await this.peer.setRemoteDescription({ 
+      type: "offer", 
+      sdp: offer 
+    });
+
+    for (const track of stream.getTracks()) {
+      this.log(`Added track ${track.kind} from ${this.channelId}`);
+      this.peer.addTrack(track, stream);
+    }
+
+    const answer = await this.peer.createAnswer();
+    await this.peer.setLocalDescription(answer);
+    await this.waitUntilIceGatheringStateComplete();
+
+    this.emit("connect");
+    return this.peer.localDescription.sdp;
+  }
+}


### PR DESCRIPTION
This PR adds the feature of maintaining a viewer count per channel. It also includes a bit of refactoring of the broadcaster implementation and handling of viewers.

It also resolves the critical issue #31 where viewers that failed to connect never released resources.