### PR TITLE
fix: need to clear connection timer when viewer has connected

### DIFF
--- a/packages/server/src/broadcaster/viewer.ts
+++ b/packages/server/src/broadcaster/viewer.ts
@@ -57,6 +57,9 @@ export class Viewer extends EventEmitter {
         console.error(err);
       }
       this.emit("disconnect");
+    } else if (this.peer.connectionState === "connected") {
+      this.log(`watcher connected, clear connection timer`);
+      clearTimeout(this.connectionTimeout);
     }
   }
 


### PR DESCRIPTION
This resolves an embarrassing mistake where connection timeout timer never was cleared when a viewer succesfully connected. 