### PR TITLE
feat: support for handling protocol extensions

### DIFF
--- a/packages/demo/src/index.ts
+++ b/packages/demo/src/index.ts
@@ -30,11 +30,14 @@ async function createClientItem(client: WHIPClient) {
   return details;
 }
 
-async function updateChannelList() {
-  const broadcasterUrl = process.env.NODE_ENV === "development" ? "http://localhost:8001/broadcaster/channel" : "https://broadcaster-wrtc.prod.eyevinn.technology/broadcaster/channel";
+async function updateChannelList(channelListUrl?: string) {
+  if (!channelListUrl) {
+    return;
+  }
+
   const channels = document.querySelector("#channels");
   channels.innerHTML = ""
-  const response = await fetch(broadcasterUrl);
+  const response = await fetch(channelListUrl);
   if (response.ok) {
     const json = await response.json();
     if (json.length > 0) {
@@ -54,7 +57,14 @@ async function ingest(client: WHIPClient, mediaStream: MediaStream) {
   await client.ingest(mediaStream);
 
   resources.appendChild(await createClientItem(client));
-  updateChannelList();
+  let channelListUrl: string;
+  (await client.getResourceExtensions()).forEach(link => {
+    if (link.match(/rel=urn:ietf:params:whip:eyevinn-wrtc-channel-list/)) {
+      channelListUrl = link.split(";")[0];      
+    }
+  });
+
+  updateChannelList(channelListUrl);
 }
 
 window.addEventListener("DOMContentLoaded", async () => {
@@ -63,8 +73,6 @@ window.addEventListener("DOMContentLoaded", async () => {
     document.querySelector<HTMLButtonElement>("#ingest-camera");
   const ingestScreen =
     document.querySelector<HTMLButtonElement>("#ingest-screen");
-
-  await updateChannelList();
 
   let authkey;
   if (process.env.NODE_ENV === "development") {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -26,6 +26,7 @@ export class WHIPClient {
 
   private peer: RTCPeerConnection;
   private resource: string;
+  private extensions: string[];
   private resourceResolve: (resource: string) => void;
   private iceGatheringTimeout;
   private iceGatheringComplete: boolean;
@@ -115,6 +116,10 @@ export class WHIPClient {
     if (response.ok) {
       this.resource = response.headers.get("Location");
       this.log("WHIP Resource", this.resource);
+
+      this.extensions = response.headers.get("Link").split(",").map(v => v.trimStart());
+      this.log("WHIP Resource Extensions", this.extensions);
+
       if (this.resourceResolve) {
         this.resourceResolve(this.resource);
         this.resourceResolve = null;
@@ -204,8 +209,13 @@ export class WHIPClient {
       return Promise.resolve(this.resource);
     }
     return new Promise((resolve) => {
-      // resolved in onIceCandidate`
+      // resolved in onIceCandidate
       this.resourceResolve = resolve;
     });
+  }
+
+  async getResourceExtensions(): Promise<string[]> {
+    await this.getResourceUrl();
+    return this.extensions;
   }
 }

--- a/packages/server/src/models/WHIPResource.ts
+++ b/packages/server/src/models/WHIPResource.ts
@@ -4,6 +4,8 @@ import { Broadcaster } from "../broadcaster";
 
 const ICE_TRICKLE_TIMEOUT = process.env.ICE_TRICKLE_TIMEOUT ? parseInt(process.env.ICE_TRICKLE_TIMEOUT) : 4000;
 
+export const IANA_PREFIX = "urn:ietf:params:whip:";
+
 // Abstract base class
 
 export interface WHIPResourceICEServer {
@@ -76,6 +78,10 @@ export class WHIPResource {
 
   getIceServers(): WHIPResourceICEServer[] {
     return this.iceServers;
+  }
+
+  getProtocolExtensions(): string[] {
+    return [];
   }
 
   private async handleConnectionStateChange() {

--- a/packages/server/src/wrtc/broadcaster.ts
+++ b/packages/server/src/wrtc/broadcaster.ts
@@ -1,5 +1,5 @@
 import { MediaStream } from "wrtc";
-import { WHIPResource, WHIPResourceICEServer } from "../models/WHIPResource";
+import { WHIPResource, WHIPResourceICEServer, IANA_PREFIX } from "../models/WHIPResource";
 
 export class WRTCBroadcaster extends WHIPResource {
 
@@ -30,6 +30,13 @@ export class WRTCBroadcaster extends WHIPResource {
 
   getType() {
     return "broadcaster";
+  }
+
+  getProtocolExtensions(): string[] {
+    return [
+      `${this.broadcaster.getBaseUrl()}/channel;rel=${IANA_PREFIX}eyevinn-wrtc-channel-list`,
+      `${this.broadcaster.getBaseUrl()}/channel/${this.getId()};rel=${IANA_PREFIX}eyevinn-wrtc-channel`,
+    ]
   }
 
   asObject(): any {

--- a/packages/server/src/wrtc/rtsp.ts
+++ b/packages/server/src/wrtc/rtsp.ts
@@ -1,4 +1,4 @@
-import { WHIPResource, WHIPResourceICEServer } from "../models/WHIPResource";
+import { WHIPResource, WHIPResourceICEServer, IANA_PREFIX } from "../models/WHIPResource";
 import { MPEGTS, MPEGTSResolution } from "../transform/mpegts";
 
 import ffmpeg from "fluent-ffmpeg";
@@ -81,6 +81,12 @@ export class WRTCRTSP extends WHIPResource {
 
   getType() {
     return "rtsp";
+  }
+
+  getProtocolExtensions(): string[] {
+    return [
+      `${this.getOutputPath()};rel=${IANA_PREFIX}eyevinn-wrtc-rtsp`,
+    ]
   }
 
   asObject(): any {


### PR DESCRIPTION
This PR adds support for WHIP endpoint types to signal using protocol extensions endpoint type specific endpoints. For example how to retrieve the channel list from the WHIP broadcaster or the RTSP url from the WHIP rtsp endpoint.