### PR TITLE
fix: free up resources on destroy and disconnect

### DIFF
--- a/packages/demo/src/index.ts
+++ b/packages/demo/src/index.ts
@@ -29,6 +29,8 @@ async function createClientItem(client: WHIPClient) {
 
   summary.innerText = await client.getResourceUrl();
 
+  const channelListUrl = await getChannelUrl(client);
+
   const links = await client.getResourceExtensions();
   links.filter(v => v.match(/urn:ietf:params:whip:/)).forEach(l => {
     const m = l.match(/<?([^>]*)>;\s*rel=([^;]*)/);
@@ -42,10 +44,10 @@ async function createClientItem(client: WHIPClient) {
   });
 
   deleteBtn.innerText = "Delete";
-  deleteBtn.onclick = async () => {
+  deleteBtn.onclick = async () => { 
     await client.destroy();
     details.parentNode?.removeChild(details);
-    updateChannelList(await getChannelUrl(client));
+    updateChannelList(channelListUrl);
   }
 
   details.appendChild(summary);

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -67,6 +67,12 @@ export class WHIPClient {
 
   private onConnectionStateChange(e) {
     this.log("PeerConnectionState", this.peer.connectionState);
+
+    switch (this.peer.connectionState) {
+      case "disconnected":
+        this.destroy();
+        break;
+    }
   }
 
   private onIceGatheringStateChange(e) {


### PR DESCRIPTION
Make sure resources on the browser side are released when connection with receiver is disconnected.