### PR TITLE
fix: remove logged error in generated js output

### DIFF
--- a/packages/sdk/spec/WHIPClient.spec.ts
+++ b/packages/sdk/spec/WHIPClient.spec.ts
@@ -250,12 +250,26 @@ describe('WHIP Client', () => {
             .once();
     });
 
-    it('Closes peer connection when connection state transitions to disconnected', async () => {
+    it('Does not close peer connection when connection state transitions to disconnected', async () => {
         when(whipProtocol.delete(anyString()))
             .thenResolve(instance(response));
 
         when(rtcPeerConnection.connectionState)
             .thenReturn('disconnected');
+
+        await whipClient.ingest(instance(mediaStream));
+        await whipClient.onConnectionStateChange(instance(event));
+
+        verify(rtcPeerConnection.close())
+            .never();
+    })
+
+    it('Closes peer connection when connection state transitions to failed', async () => {
+        when(whipProtocol.delete(anyString()))
+            .thenResolve(instance(response));
+
+        when(rtcPeerConnection.connectionState)
+            .thenReturn('failed');
 
         await whipClient.ingest(instance(mediaStream));
         await whipClient.onConnectionStateChange(instance(event));

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -144,11 +144,8 @@ export class WHIPClient extends EventEmitter {
 
   async onConnectionStateChange(event: Event) {
     this.log("PeerConnectionState", this.peer.connectionState);
-
-    switch (this.peer.connectionState) {
-      case "disconnected":
-        await this.destroy();
-        break;
+    if (this.peer.connectionState === 'failed') {
+      await this.destroy();
     }
   }
 


### PR DESCRIPTION
* case statement resulted in broken js output, use if instead.
* teardown on failed state instead of disconnected, since disconnected can recover automatically