### PR TITLE
fix: prevent server from crashing if channel does not exist

### DIFF
--- a/packages/server/src/broadcaster/index.ts
+++ b/packages/server/src/broadcaster/index.ts
@@ -152,6 +152,9 @@ export class Broadcaster {
 
   getViewerCount(channelId: string): number {
     const channel = this.channels.get(channelId);
+    if (!channel) {
+      return 0;
+    }
     return channel.getViewers().length;
   }
  


### PR DESCRIPTION
This PR fixes an issue that could cause the server to crash if viewer count was requested on a channel that does not exist.