### PR TITLE
fix: handle relative WHIP resource URLs

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -260,7 +260,7 @@ export class WHIPClient extends EventEmitter {
     if (response.ok) {
       this.resource = response.headers.get("Location");
       if (!this.resource.match(/^http/)) {
-        this.resource = this.whipEndpoint.protocol + "//" + this.whipEndpoint.host + this.resource;
+        this.resource = new URL(this.resource, this.whipEndpoint).toString();
       }
       this.log("WHIP Resource", this.resource);
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -259,6 +259,9 @@ export class WHIPClient extends EventEmitter {
 
     if (response.ok) {
       this.resource = response.headers.get("Location");
+      if (!this.resource.match(/^http/)) {
+        this.resource = this.whipEndpoint.protocol + "//" + this.whipEndpoint.host + this.resource;
+      }
       this.log("WHIP Resource", this.resource);
 
       this.eTag = response.headers.get("ETag");


### PR DESCRIPTION
This PR addresses issue #115 where Cloudflare (for example) returns relative URL in the Location header in the POST (offer) response