### PR TITLE
feat: if no hostname is set return relative WHIP resource URL

### DIFF
--- a/packages/server/src/whip/whipEndpoint.ts
+++ b/packages/server/src/whip/whipEndpoint.ts
@@ -40,7 +40,7 @@ export class WhipEndpoint {
     this.extPort = opts?.extPort || this.port;
     this.interfaceIp = opts?.interfaceIp || "0.0.0.0";
     this.useHttps = !!(opts?.https);
-    this.hostname = opts?.hostname || "localhost";
+    this.hostname = opts?.hostname;
     this.enabledWrtcPlugins = opts?.enabledWrtcPlugins || [];
     this.iceServers = opts?.iceServers || [];
     this.tls = opts?.tls;
@@ -134,8 +134,11 @@ export class WhipEndpoint {
     return this.iceServers;
   }
 
-  getServerAddress(): string {
-    return (this.useHttps ? "https" : "http") + "://" + this.hostname + ":" + this.extPort;
+  getServerAddress(): string | undefined {
+    if (this.hostname) {
+      return (this.useHttps ? "https" : "http") + "://" + this.hostname + ":" + this.extPort;
+    }
+    return undefined;
   }
 
   listen() {

--- a/packages/server/src/whip/whipFastifyApi.ts
+++ b/packages/server/src/whip/whipFastifyApi.ts
@@ -65,9 +65,16 @@ export default function(fastify: FastifyInstance, opts, done) {
       await resource.connect();
       const sdpAnswer = await resource.sdpAnswer();
 
+      let locationUrl;
+      // If no hostname is configured we return relative WHIP resource URL
+      if (opts.instance.getServerAddress()) {
+        locationUrl = `${opts.instance.getServerAddress()}${opts.prefix}/whip/${type}/${resource.getId()}`;
+      } else {
+        locationUrl = `${opts.prefix}/whip/${type}/${resource.getId()}`;
+      }
       reply.headers({
         "Content-Type": "application/sdp",
-        "Location": `${opts.instance.getServerAddress()}${opts.prefix}/whip/${type}/${resource.getId()}`,
+        "Location": locationUrl,
         "ETag": resource.getETag()
       });
       


### PR DESCRIPTION
If no hostname is provided the WHIP endpoint will return a relative URL for the WHIP resource URL returned in the POST response