### PR TITLE
fix: sfu whip resource tries to set properties of undefined when no audio

### DIFF
--- a/packages/server/src/whip/sfu/sfuWhipResource.ts
+++ b/packages/server/src/whip/sfu/sfuWhipResource.ts
@@ -257,7 +257,9 @@ export class SfuWhipResource implements WhipResource {
       ];
     }
 
-    edgeEndpointDesc.audio.ssrcs = [];
+    if (offerAudio) {
+      edgeEndpointDesc.audio.ssrcs = [];
+    }
     edgeEndpointDesc.video.streams = [];
     edgeEndpointDesc['bundle-transport'].dtls.setup = 'active';
 


### PR DESCRIPTION
I tried the instructions and sharing a browser tab (no audio) rather than webcam. This resulted in `TypeError: Cannot set properties of undefined (setting 'ssrcs') at SfuWhipResource.setupEdgeSfu`

I'm not sure if this is the right thing to check/do, rather than `if (edgeEndpointDesc.audio)`, but it worked and it's similar to the condition on line 244.