### PR TITLE
fix: add resource null check to sendOffer

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -276,7 +276,7 @@ export class WHIPClient extends EventEmitter {
 
     if (response.ok) {
       this.resource = response.headers.get("Location");
-      if (!this.resource.match(/^http/)) {
+      if (this.resource && !this.resource.match(/^http/)) {
         this.resource = new URL(this.resource, this.whipEndpoint).toString();
       }
       this.log("WHIP Resource", this.resource);


### PR DESCRIPTION
This PR addresses issue #131 where a null value was causing the match function to throw an error in the sendOffer method of the WHIP client. This fix adds a null check before calling match to prevent this error from occurring.

I have tested these changes with and without the null check, and confirmed that the null check fixes my issue.