### PR TITLE
conform to whip auth header spec, fixes: https://github.com/Eyevinn/w…

### DIFF
--- a/packages/sdk/src/WHIPProtocol.ts
+++ b/packages/sdk/src/WHIPProtocol.ts
@@ -5,7 +5,7 @@ export class WHIPProtocol {
             method: "POST",
             headers: {
                 "Content-Type": "application/sdp",
-                "Authorization": authKey
+                "Authorization": `Bearer ${authKey}`
             },
             body: sdp
         });
@@ -15,7 +15,7 @@ export class WHIPProtocol {
         return fetch(url, {
             method: "OPTIONS",
             headers: {
-                "Authorization": authKey,
+                "Authorization": `Bearer ${authKey}`,
             }
         });
     }
@@ -31,7 +31,8 @@ export class WHIPProtocol {
             method: "PATCH",
             headers: {
                 "Content-Type": "application/trickle-ice-sdpfrag",
-                "ETag": eTag
+                "ETag": eTag,
+                "Authorization": `Bearer ${authKey}`,
             },
             body: sdp
         });


### PR DESCRIPTION
…hip/issues/128

Section 4.5 of draft-ietf-wish-whip-08 says:

WHIP endpoints and resources MAY require the HTTP request to be authenticated using an HTTP Authorization header field with a Bearer token as specified in [RFC6750] section 2.1.

Section 2.1 of RFC 6750 specifies the syntax as:

credentials = "Bearer" 1*SP b64token

So lines 8 and 18 of WhipProtocol.ts should say