### PR TITLE
Add authorization for delete endpoint in SDK

### DIFF
--- a/packages/sdk/spec/WHIPClient.spec.ts
+++ b/packages/sdk/spec/WHIPClient.spec.ts
@@ -470,7 +470,7 @@ describe('WHIP Client', () => {
     });
 
     it('Does not close peer connection when connection state transitions to disconnected', async () => {
-        when(whipProtocol.delete(anyString()))
+        when(whipProtocol.delete(anyString(), undefined))
             .thenResolve(instance(response));
 
         when(rtcPeerConnection.connectionState)
@@ -484,7 +484,7 @@ describe('WHIP Client', () => {
     })
 
     it('Closes peer connection when connection state transitions to failed', async () => {
-        when(whipProtocol.delete(anyString()))
+        when(whipProtocol.delete(anyString(), undefined))
             .thenResolve(instance(response));
 
         when(rtcPeerConnection.connectionState)

--- a/packages/sdk/src/WHIPProtocol.ts
+++ b/packages/sdk/src/WHIPProtocol.ts
@@ -1,42 +1,60 @@
 export class WHIPProtocol {
 
     sendOffer(url: string, authKey: string | undefined, sdp: string): Promise<Response> {
+        const headers = {
+            "Content-Type": "application/sdp",
+        };
+
+        if (authKey) {
+            headers['Authorization'] = `Bearer ${authKey}`;
+        }
+
         return fetch(url, {
             method: "POST",
-            headers: {
-                "Content-Type": "application/sdp",
-                "Authorization": `Bearer ${authKey}`
-            },
+            headers,
             body: sdp
         });
     }
 
     getConfiguration(url: string, authKey: string | undefined): Promise<Response> {
+        const headers = {};
+
+        if (authKey) {
+            headers['Authorization'] = `Bearer ${authKey}`;
+        }
+
         return fetch(url, {
             method: "OPTIONS",
-            headers: {
-                "Authorization": `Bearer ${authKey}`,
-            }
+            headers
         });
     }
 
     delete(url: string, authKey: string | undefined): Promise<Response> {
+        const headers = {};
+
+        if (authKey) {
+            headers['Authorization'] = `Bearer ${authKey}`;
+        }
+
         return fetch(url, {
             method: "DELETE",
-            headers: {
-                "Authorization": `Bearer ${authKey}`,
-            }
+            headers
         });
     }
 
     updateIce(url: string, eTag: string, sdp: string, authKey: string | undefined): Promise<Response> {
+        const headers = {
+            "Content-Type": "application/trickle-ice-sdpfrag",
+            "ETag": eTag,
+        };
+
+        if (authKey) {
+            headers['Authorization'] = `Bearer ${authKey}`;
+        }
+
         return fetch(url, {
             method: "PATCH",
-            headers: {
-                "Content-Type": "application/trickle-ice-sdpfrag",
-                "ETag": eTag,
-                "Authorization": `Bearer ${authKey}`,
-            },
+            headers,
             body: sdp
         });
     }

--- a/packages/sdk/src/WHIPProtocol.ts
+++ b/packages/sdk/src/WHIPProtocol.ts
@@ -20,9 +20,12 @@ export class WHIPProtocol {
         });
     }
 
-    delete(url: string): Promise<Response> {
+    delete(url: string, authKey: string | undefined): Promise<Response> {
         return fetch(url, {
-            method: "DELETE"
+            method: "DELETE",
+            headers: {
+                "Authorization": `Bearer ${authKey}`,
+            }
         });
     }
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -384,7 +384,7 @@ export class WHIPClient extends EventEmitter {
  */
   async destroy(): Promise<void> {
     const resourceUrl = await this.getResourceUrl();
-    await this.whipProtocol.delete(resourceUrl).catch((e) => this.error("destroy()", e));
+    await this.whipProtocol.delete(resourceUrl, this.opts.authkey).catch((e) => this.error("destroy()", e));
 
     const senders = this.peer.getSenders();
     if (senders) {


### PR DESCRIPTION
The delete endpoint in the SDK was missing the Authorization header, but the [RFC](https://datatracker.ietf.org/doc/rfc9725/) says the following in the 4.7.1. section:

> WHIP clients MUST implement this authentication and authorization mechanism and send the HTTP Authorization header field in all HTTP requests sent to either the WHIP endpoint or session (except the preflight OPTIONS requests for CORS).

I kindly ask you to merge this PR since without it our client is not working with our backend (different library than your server implementation).